### PR TITLE
symfony/css-selector 3.0 incompatible with present code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require":      {
         "php":  ">=5.3.6",
-        "symfony/css-selector": "*"
+        "symfony/css-selector": "2.*"
     },
     "autoload":     {
         "psr-0": { "Artack\\DOMQuery\\": "src/" }


### PR DESCRIPTION
Lock in dependency to be pre-3.0 symfony/css-selector, changes in 3.0 break this project.
